### PR TITLE
feat: enhance commit message trailer handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Note: works well with [vault-plugin-secrets-github](https://github.com/martinbai
 
 ## Configuration
 
-If the current working directory is a git repository, the first GitHub remote (if there is one) is used to infer default repository owner (`--owner`) and name (`--repo`), the current branch is used to set the default branch (`--branch`), and resolved git config is used to set a default author for generated `Signed-off-by` message suffix (`--user.name` and `--user.email`) to help distinguish between different systems sharing common GitHub App credentials.
+If the current working directory is a git repository, the first GitHub remote (if there is one) is used to infer default repository owner (`--owner`) and name (`--repo`), the current branch is used to set the default branch (`--branch`), and resolved git config is used to set a default author for generated `Signed-off-by` message suffix (`--trailer.name` and `--trailer.email`) to help distinguish between different systems sharing common GitHub App credentials.
 
 If run outside a GitHub repository, then the `--owner` and `--repo` flags are required, with `--branch` defaulting to `main`.
 
-All configuration may be passed via environment variable rather than flag. The environment variable associated with each flag is `GHUP_[UPPERCASED_FLAG_NAME]`, e.g. `GHUP_TOKEN`, `GHUP_OWNER`, `GHUP_REPO`, `GHUP_BRANCH`, `GHUP_NO_SIGNOFF`, etc.
+All configuration may be passed via environment variable rather than flag. The environment variable associated with each flag is `GHUP_[UPPERCASED_FLAG_NAME]`, e.g. `GHUP_TOKEN`, `GHUP_OWNER`, `GHUP_REPO`, `GHUP_BRANCH`, `GHUP_TRAILER_KEY`, etc.
 
 In addition, various fallback environment variables are supported for better integration with Jenkins and similar CI tools: `GITHUB_OWNER`, `GITHUB_TOKEN`, `CHANGE_BRANCH`, `BRANCH_NAME`, `GIT_BRANCH`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`, etc.
 
-For security, it is strongly recommended that the GitHub Token by passed via environment (`GHUP_TOKEN` or `GITHUB_TOKEN`) or file path (`--token /path/to/protected-token-file`)
+For security, it is strongly recommended that the GitHub Token by passed via environment (`GHUP_TOKEN` or `GITHUB_TOKEN`) or, better, file path (`--token /path/to/token-file`)
 
 ## Usage
 
@@ -44,23 +44,24 @@ Usage:
   ghup tag [flags] [<name>]
 
 Flags:
-  -h, --help         help for tag
-      --tag string   tag name
+  -h, --help          help for tag
+      --lightweight   force lightweight tag
+      --tag string    tag name
 
 Global Flags:
-  -b, --branch string       branch name (default "[local-branch-or-main]")
-  -f, --force               force action
-  -m, --message string      message
-      --no-signoff          don't add Signed-off-by to message
-  -o, --owner string        repository owner (default "[owner-of-first-github-remote-or-required]")
-  -r, --repo string         repository name (default "[repo-of-first-github-remote-or-required]")
-      --token string        GitHub Token or path/to/token-file
-      --user.email string   user email for sign-off (default "[user.email]")
-      --user.name string    user name for sign-off (default "[user.name]")
-  -v, --verbosity count     verbosity
+  -b, --branch string          branch name (default "[local-branch-or-main]")
+  -f, --force                  force action
+  -m, --message string         message (default "Commit via API")
+  -o, --owner string           repository owner (default "[owner-of-first-github-remote-or-required]")
+  -r, --repo string            repository name (default "[repo-of-first-github-remote-or-required]")
+      --token string           GitHub Token or path/to/token-file
+      --trailer.email string   email for commit trailer (default "[user.email]")
+      --trailer.key string     key for commit trailer (blank to disable) (default "Co-Authored-By")
+      --trailer.name string    name for commit trailer (default "[user.name]")
+  -v, --verbosity count        verbosity
 ```
 
-Note: only lightweight tags (no message and `--no-signoff`), which simply point at an existing commit, are "verified".
+Note: annotated tags are the default, but only lightweight tags (i.e. `--lightweight`), which simply point at an existing commit, are "verified".
 
 #### Tagging Example
 
@@ -88,16 +89,16 @@ Flags:
   -u, --update stringArray   file-spec to update
 
 Global Flags:
-  -b, --branch string       branch name (default "[local-branch-or-main]")
-  -f, --force               force action
-  -m, --message string      message
-      --no-signoff          don't add Signed-off-by to message
-  -o, --owner string        repository owner (default "[owner-of-first-github-remote-or-required]")
-  -r, --repo string         repository name (default "[repo-of-first-github-remote-or-required]")
-      --token string        GitHub Token or path/to/token-file
-      --user.email string   user email for sign-off (default "[user.email]")
-      --user.name string    user name for sign-off (default "[user.name]")
-  -v, --verbosity count     verbosity
+  -b, --branch string          branch name (default "[local-branch-or-main]")
+  -f, --force                  force action
+  -m, --message string         message (default "Commit via API")
+  -o, --owner string           repository owner (default "[owner-of-first-github-remote-or-required]")
+  -r, --repo string            repository name (default "[repo-of-first-github-remote-or-required]")
+      --token string           GitHub Token or path/to/token-file
+      --trailer.email string   email for commit trailer (default "[user.email]")
+      --trailer.key string     key for commit trailer (blank to disable) (default "Co-Authored-By")
+      --trailer.name string    name for commit trailer (default "[user.name]")
+  -v, --verbosity count        verbosity
 ```
 
 Each `file-spec` provided as a positional argument or explicitly via the `--update` flag takes the form `<local-file-path>[:<remote-target-path>]`. Content is read from the local file `<local-file-path>` and written to `<remote-target-path>` (defaulting to `<local-file-path>` if not specified).

--- a/cmd/content.go
+++ b/cmd/content.go
@@ -101,7 +101,7 @@ func runContentCmd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	message = util.BuildCommitMessage(!noSignOff)
+	message = util.BuildCommitMessage()
 
 	input := githubv4.CreateCommitOnBranchInput{
 		Branch:          remote.CommittableBranch(owner, repo, branch),

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -10,8 +10,8 @@ import (
 )
 
 type info struct {
-	HasToken   bool `yaml:"hasToken"`
-	Committer  string
+	HasToken   bool   `yaml:"hasToken"`
+	Trailer    string `yaml:"trailer,omitempty"`
 	Owner      string
 	Repository string
 	Branch     string
@@ -34,7 +34,7 @@ func init() {
 func runInfoCmd(cmd *cobra.Command, args []string) (err error) {
 	i := info{
 		HasToken:   len(viper.GetString("token")) > 0,
-		Committer:  util.BuildCommitter(),
+		Trailer:    util.BuildTrailer(),
 		Owner:      owner,
 		Repository: repo,
 		Branch:     branch,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,12 +26,11 @@ var (
 	defaultRepo      string
 	defaultBranch    string = "main"
 
-	owner     string
-	repo      string
-	branch    string
-	message   string
-	noSignOff bool
-	force     bool
+	owner   string
+	repo    string
+	branch  string
+	message string
+	force   bool
 )
 
 var rootCmd = &cobra.Command{
@@ -84,19 +83,19 @@ func init() {
 	viper.BindPFlag("branch", rootCmd.PersistentFlags().Lookup("branch"))
 	viper.BindEnv("branch", "GHUP_BRANCH", "CHANGE_BRANCH", "BRANCH_NAME", "GIT_BRANCH")
 
-	rootCmd.PersistentFlags().StringP("message", "m", "", "message")
+	rootCmd.PersistentFlags().StringP("message", "m", "Commit via API", "message")
 	viper.BindPFlag("message", rootCmd.PersistentFlags().Lookup("message"))
 
-	rootCmd.PersistentFlags().BoolVar(&noSignOff, "no-signoff", false, "don't add Signed-off-by to message")
-	viper.BindPFlag("no_signoff", rootCmd.PersistentFlags().Lookup("no-signoff"))
+	rootCmd.PersistentFlags().String("trailer.key", "Co-Authored-By", "key for commit trailer (blank to disable)")
+	viper.BindPFlag("trailer.key", rootCmd.PersistentFlags().Lookup("trailer.key"))
 
-	rootCmd.PersistentFlags().String("user.name", defaultUserName, "user name for sign-off")
-	viper.BindPFlag("user.name", rootCmd.PersistentFlags().Lookup("user.name"))
-	viper.BindEnv("user.name", "GHUP_USER_NAME", "GIT_COMMITTER_NAME", "GIT_AUTHOR_NAME")
+	rootCmd.PersistentFlags().String("trailer.name", defaultUserName, "name for commit trailer")
+	viper.BindPFlag("trailer.name", rootCmd.PersistentFlags().Lookup("trailer.name"))
+	viper.BindEnv("trailer.name", "GHUP_USER_NAME", "GIT_COMMITTER_NAME", "GIT_AUTHOR_NAME")
 
-	rootCmd.PersistentFlags().String("user.email", defaultUserEmail, "user email for sign-off")
-	viper.BindPFlag("user.email", rootCmd.PersistentFlags().Lookup("user.email"))
-	viper.BindEnv("user.email", "GHUP_USER_EMAIL", "GIT_COMMITTER_EMAIL", "GIT_AUTHOR_EMAIL")
+	rootCmd.PersistentFlags().String("trailer.email", defaultUserEmail, "email for commit trailer")
+	viper.BindPFlag("trailer.email", rootCmd.PersistentFlags().Lookup("trailer.email"))
+	viper.BindEnv("trailer.email", "GHUP_USER_EMAIL", "GIT_COMMITTER_EMAIL", "GIT_AUTHOR_EMAIL")
 
 	rootCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "force action")
 	viper.BindPFlag("force", rootCmd.PersistentFlags().Lookup("force"))

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -27,6 +27,9 @@ func init() {
 	tagCmd.Flags().String("tag", "", "tag name")
 	viper.BindPFlag("tag", tagCmd.Flags().Lookup("tag"))
 
+	tagCmd.Flags().Bool("lightweight", false, "force lightweight tag")
+	viper.BindPFlag("lightweight", tagCmd.Flags().Lookup("lightweight"))
+
 	rootCmd.AddCommand(tagCmd)
 }
 
@@ -67,9 +70,7 @@ func runTagCmd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	message = util.BuildCommitMessage(!noSignOff)
-
-	if message != "" {
+	if message = util.BuildCommitMessage(); message != "" && !viper.GetBool("lightweight") {
 		annotatedTag := &github.Tag{
 			Tag:     &tagName,
 			Message: &message,


### PR DESCRIPTION
* Default commit message to "Commit via API" to ensure trailer isn't
  promoted to commit title.
* Add a warning when a message with a title exceeding 72 characters is
  used.
* Switch from the hard-coded "Signed-off-by" trailer to (configurable)
  "Co-Authored-By" for enhanced author presentation on GitHub.
  This switches the associated flags from `no-signoff`, `user.name` and
  `user.email` to `trailer.key`, `trailer.name` and `trailer.email`.
* Add `--lightweight` flag to `ghup tag` to force creation of
  lightweight tag.