### PR TITLE
feature(deployment-cmd): allow creating deployments when required status checks are set for branch/env

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -55,6 +55,7 @@ func cmdDeployment() *cobra.Command {
 
 	flags.BoolP("transient", "T", false, "transient environment")
 	flags.BoolP("production", "P", false, "production environment")
+	flags.Bool("bypass-checks", false, "bypass branch protection status checks when creating deployment")
 	flags.String("description", "", "deployment description")
 	flags.String("environment-url", "", "environment URL")
 
@@ -141,9 +142,10 @@ func runDeploymentCmd(cmd *cobra.Command, args []string) error {
 			transient := viper.GetBool("transient")
 			production := viper.GetBool("production")
 			description := viper.GetString("description")
+			bypassChecks := viper.GetBool("bypass-checks")
 
 			log.Infof("creating deployment for %s in %s environment", commitish, environment)
-			deployment, err = client.CreateDeploymentV3(commitish, environment, description, transient, production)
+			deployment, err = client.CreateDeploymentV3(commitish, environment, description, transient, production, bypassChecks)
 			if err != nil {
 				output.SetError(fmt.Errorf("creating deployment: %w", err))
 				return cmdOutput(cmd, output)

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -21,6 +21,7 @@ type deploymentTestArgs struct {
 	Production     bool
 	Description    string
 	EnvironmentURL string
+	BypassChecks   bool
 	DryRun         bool
 }
 
@@ -53,6 +54,10 @@ func (s *deploymentTestArgs) Slice() []string {
 
 	if s.EnvironmentURL != "" {
 		args = append(args, "--environment-url", s.EnvironmentURL)
+	}
+
+	if s.BypassChecks {
+		args = append(args, "--bypass-checks")
 	}
 
 	if s.DryRun {

--- a/internal/remote/client.go
+++ b/internal/remote/client.go
@@ -863,8 +863,9 @@ func (c *Client) ListDeploymentsV3(sha, environment string) ([]DeploymentInfo, e
 	return deploymentInfos, nil
 }
 
-// CreateDeploymentV3 creates a deployment using REST API (hybrid approach)
-func (c *Client) CreateDeploymentV3(ref, environment, description string, transient, production bool) (*DeploymentInfo, error) {
+// CreateDeploymentV3 creates a deployment using REST API (hybrid approach).
+// When bypassChecks is true, required_contexts is set to an empty slice to bypass branch protection status checks.
+func (c *Client) CreateDeploymentV3(ref, environment, description string, transient, production, bypassChecks bool) (*DeploymentInfo, error) {
 	deploymentReq := &github.DeploymentRequest{
 		Ref:                   &ref,
 		Environment:           &environment,
@@ -874,6 +875,11 @@ func (c *Client) CreateDeploymentV3(ref, environment, description string, transi
 
 	if description != "" {
 		deploymentReq.Description = &description
+	}
+
+	if bypassChecks {
+		emptyContexts := []string{}
+		deploymentReq.RequiredContexts = &emptyContexts
 	}
 
 	deployment, _, err := c.V3.Repositories.CreateDeployment(c.context, c.repo.Owner, c.repo.Name, deploymentReq)


### PR DESCRIPTION
…tus checks are set for branch/env

no flag, same as before change:
```
go run main.go deployment --owner nexthink --repo gitops.test-cdv --commitish 0fe0cedfc7fea884f347fcee48d18769d10d5e1e --environment dev/mtp/eu-central-1/main --state=success --production
{
  "deployment_id": 0,
  "status_id": 0,
  "environment": "dev/mtp/eu-central-1/main",
  "commitish": "0fe0cedfc7fea884f347fcee48d18769d10d5e1e",
  "sha": "0fe0cedfc7fea884f347fcee48d18769d10d5e1e",
  "state": "success",
  "url": "https://github.com/nexthink/gitops.test-cdv/commit/0fe0cedfc7fea884f347fcee48d18769d10d5e1e",
  "created": false,
  "error": "creating deployment: POST https://api.github.com/repos/nexthink/gitops.test-cdv/deployments: 409 Conflict: Commit status checks failed for 0fe0cedfc7fea884f347fcee48d18769d10d5e1e. [{Resource:Deployment Field:required_contexts Code:invalid Message:}]"
}
exit status 1
```

after:
```
go run main.go deployment --owner nexthink --repo gitops.test-cdv --commitish 0fe0cedfc7fea884f347fcee48d18769d10d5e1e --environment dev/mtp/eu-central-1/main --state=success --production --bypass-checks
{
  "deployment_id": 4442074271,
  "status_id": 12690168079,
  "environment": "dev/mtp/eu-central-1/main",
  "commitish": "0fe0cedfc7fea884f347fcee48d18769d10d5e1e",
  "sha": "0fe0cedfc7fea884f347fcee48d18769d10d5e1e",
  "state": "success",
  "url": "https://github.com/nexthink/gitops.test-cdv/commit/0fe0cedfc7fea884f347fcee48d18769d10d5e1e",
  "created": true
}
```