### PR TITLE
fix: support running from linked git worktrees

### DIFF
--- a/internal/local/repository.go
+++ b/internal/local/repository.go
@@ -34,9 +34,6 @@ type DeletionSet map[string]struct{}
 
 // SetDefaults implements defaults.Setter interface
 func (r *Repository) SetDefaults() {
-	// EnableDotGitCommonDir is required for linked worktrees (git worktree),
-	// where config, refs and objects live in the parent repository's common
-	// directory rather than the worktree's own gitdir.
 	options := &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true}
 	repo, err := git.PlainOpenWithOptions(r.Path, options)
 	if err != nil {

--- a/internal/local/repository.go
+++ b/internal/local/repository.go
@@ -34,7 +34,10 @@ type DeletionSet map[string]struct{}
 
 // SetDefaults implements defaults.Setter interface
 func (r *Repository) SetDefaults() {
-	options := &git.PlainOpenOptions{DetectDotGit: true}
+	// EnableDotGitCommonDir is required for linked worktrees (git worktree),
+	// where config, refs and objects live in the parent repository's common
+	// directory rather than the worktree's own gitdir.
+	options := &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true}
 	repo, err := git.PlainOpenWithOptions(r.Path, options)
 	if err != nil {
 		return

--- a/internal/local/repository_test.go
+++ b/internal/local/repository_test.go
@@ -1,6 +1,10 @@
 package local
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -203,5 +207,90 @@ func TestParseRemote_Examples(t *testing.T) {
 				t.Errorf("parseRemote() gotRepo = %v, want %v", gotRepo, tt.wantRepo)
 			}
 		})
+	}
+}
+
+// TestRepository_LinkedWorktree verifies that ghup works from a linked git
+// worktree (created with `git worktree add`), where the .git entry is a file
+// pointing into the parent repository's .git/worktrees/<name> directory and
+// most repository data (config, refs, objects) lives in the common directory.
+func TestRepository_LinkedWorktree(t *testing.T) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not available")
+	}
+
+	tmp := t.TempDir()
+	mainDir := filepath.Join(tmp, "main")
+	worktreeDir := filepath.Join(tmp, "wt")
+
+	git := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(gitPath, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	if err := os.Mkdir(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(mainDir, "init", "--initial-branch=main")
+	git(mainDir, "remote", "add", "origin", "https://github.com/test-owner/test-repo.git")
+	for name, content := range map[string]string{
+		"staged.txt":    "original\n",
+		"untouched.txt": "untouched\n",
+	} {
+		if err := os.WriteFile(filepath.Join(mainDir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(mainDir, "add", ".")
+	git(mainDir, "commit", "--no-gpg-sign", "-m", "initial")
+	git(mainDir, "worktree", "add", worktreeDir, "-b", "feature")
+
+	// stage a change in the linked worktree
+	if err := os.WriteFile(filepath.Join(worktreeDir, "staged.txt"), []byte("updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(worktreeDir, "add", "staged.txt")
+
+	repo := &Repository{Path: worktreeDir}
+	repo.SetDefaults()
+
+	if repo.Repository == nil {
+		t.Fatal("SetDefaults() failed to open linked worktree")
+	}
+	if repo.Branch != "feature" {
+		t.Errorf("Branch = %q, want %q", repo.Branch, "feature")
+	}
+	if repo.Owner != "test-owner" || repo.Name != "test-repo" {
+		t.Errorf("Owner/Name = %q/%q, want test-owner/test-repo (remote lookup requires the common directory's config)", repo.Owner, repo.Name)
+	}
+
+	status, err := repo.Status()
+	if err != nil {
+		t.Fatalf("Status() error: %v", err)
+	}
+
+	pathContent, deletionSet, err := repo.Staged(status)
+	if err != nil {
+		t.Fatalf("Staged() error: %v", err)
+	}
+	if len(deletionSet) != 0 {
+		t.Errorf("Staged() deletionSet = %v, want empty", deletionSet.Keys())
+	}
+	if want := []string{"staged.txt"}; !slices.Equal(pathContent.Keys(), want) {
+		t.Errorf("Staged() paths = %v, want %v (unstaged tracked files must not be reported)", pathContent.Keys(), want)
+	}
+	if got := string(pathContent["staged.txt"]); got != "updated\n" {
+		t.Errorf("Staged() content = %q, want %q", got, "updated\n")
 	}
 }


### PR DESCRIPTION
## Problem

Running any `ghup` command from a linked git worktree (created with `git worktree add`) misbehaves:

- owner/repo/branch autodetection silently fails, so `--owner`/`--repo` must be passed by hand
- `ghup content --staged` fails outright with `finding blob for ... object not found` — for **every tracked file in the repo**, not just staged ones

## Root cause

`internal/local.(*Repository).SetDefaults` opens the repository with `git.PlainOpenOptions{DetectDotGit: true}` only. In a linked worktree, `.git` is a file pointing at `<main>/.git/worktrees/<name>`, and go-git's support for the `commondir` redirection that git places there is **opt-in** via `PlainOpenOptions.EnableDotGitCommonDir`. Without it, go-git treats `.git/worktrees/<name>` as the entire gitdir, so config, refs and the object database (which all live in the parent repository's common directory) are invisible:

- no config → remote `origin` not found → owner/repo autodetection fails
- no refs → `HEAD` unresolvable → branch autodetection fails, and `worktree.Status()` diffs the index against nothing, reporting every tracked file as staged-`Added`
- no objects → `BlobObject(entry.Hash)` returns `object not found` for each of those entries

## Fix

Set `EnableDotGitCommonDir: true` alongside `DetectDotGit: true`. The option has no effect on plain checkouts (it only kicks in when a `commondir` file is present in the resolved gitdir), so regular-repo behaviour is unchanged — verified by the existing suite plus a manual `--dry-run` from both a plain checkout and a linked worktree.

## Test

Adds `TestRepository_LinkedWorktree`, which builds a real repository + linked worktree via the git CLI (skips when `git` is unavailable, hermetic from user/system git config), stages one change, and asserts branch/owner/repo detection and that `Staged()` returns exactly the staged file with its staged content. Fails before the fix with all three symptoms above; passes after.